### PR TITLE
added set/get requests

### DIFF
--- a/backend/src/schema.hpp
+++ b/backend/src/schema.hpp
@@ -230,7 +230,7 @@ compose_schema() {
         {"properties",{{"options",j_options},
                        {"settings",j_settings},
                        {"graph",j_graph},
-                       {"WM",j_wm}}}
+                       {"wm",j_wm}}}
     };
 
 /* ----------------------- Root ------------------------------ */

--- a/backend/src/schema.hpp
+++ b/backend/src/schema.hpp
@@ -206,6 +206,33 @@ compose_schema() {
                                   {"uniqueItems",true}}}}}
     };
 
+/* ----------------------- Get request ----------------------- */
+
+    const json j_get_requests = {
+        {{"type","string"},
+         {"enum",{{"options","settings","WM","graph"}}}}
+    };
+
+    const json j_get = {
+        {"comment","JSON schema for get requests"},
+        {"oneOf",{j_get_requests,
+                  {{"type","array"},
+                   {"uniqueItems",true},
+                   {"items",j_get_requests}}}}
+    };
+
+/* ----------------------- Set request ----------------------- */
+
+    const json j_set = {
+        {"comment","JSON schema for set requests"},
+        {"type","object"},
+        {"additionalProperties",false},
+        {"properties",{{"options",j_options},
+                       {"settings",j_settings},
+                       {"graph",j_graph},
+                       {"WM",j_wm}}}
+    };
+
 /* ----------------------- Root ------------------------------ */
 
     const json j_definitions = {
@@ -244,11 +271,10 @@ compose_schema() {
         {"comment","JSON schema for data passed to backend"},
         {"type","object"},
         {"additionalProperties",false},
-        {"properties",{{"get",{{"type","string"}}},
-                       {"options",j_options},
-                       {"settings",j_settings},
-                       {"graph",j_graph},
-                       {"WM",j_wm}}},
+        {"maxProperties",1},
+        {"minProperties",1},
+        {"properties",{{"get",j_get},
+                       {"set",j_set}}},
         {"definitions",j_definitions}
     };
 

--- a/backend/src/wm.hpp
+++ b/backend/src/wm.hpp
@@ -21,7 +21,7 @@ namespace Ats {
         typedef std::pair<uint,uint> resolution_t;
 
     public:
-        Wm() : Chatterer ("WM") {}
+        Wm() : Chatterer ("wm") {}
         Wm(Wm&&) = delete;
         Wm(const Wm&) = delete;
         virtual ~Wm() {}

--- a/backend/src/wm_chatterer.cpp
+++ b/backend/src/wm_chatterer.cpp
@@ -110,14 +110,14 @@ Wm::serialize() const {
     json j_windows(windows_v);
     json j_widgets(widgets_v);
 
-    json j_treeview;
+    json j_treeview = json::array();
     f_containers_t f = [&j_treeview](const std::string& s,const Wm_container& c) {
         json j_container = {s,c};
         j_treeview.push_back(j_container);
     };
     _treeview.for_each(f);
 
-    json j = json{{"background",{}},
+    json j = json{{"background",json::object()}, // FIXME
                   {"resolution",{_resolution.first,_resolution.second}},
                   {"windows",j_windows},
                   {"widgets",j_widgets},


### PR DESCRIPTION
* added set/get requests

## Set request

#### Request syntax
{"set": {object with the following keys : `options`, `settings`, `graph`, `wm`}}
NOTE: rules for inner objects are described in schema.hpp

#### Return value
{"ok",{array with keys as in request}}
or
{"error",string describing error}

## Get request

#### Request syntax
{"get": string or array of strings with the following items [`options`,`settings`,`graph`,`wm`]}

#### Return value
{"ok",{object with keys as in request and corresponding values}}
or
{"error",string describing error}